### PR TITLE
travis: Add a basic integration test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - 10
+
+install:
+  - yarn
+script:
+  - yarn build
+
+cache: yarn


### PR DESCRIPTION
This defines build instructions for the travis-ci.org continuous
integration service which can provide feedback on commits and
pull requests on github.

- Build on node v10.

  This is the current Long Term Support release so it's a good
  basis for testing.

  I tried to add current stable (v12.3.1) as well to get some
  advance notice of breakage, but it fails trying to compile
  the native fibres module.

- Explicitly invoke `yarn` and `yarn build`

  By default, the travis environment calls `yarn test` which
  isn't hooked up currently.

  The repo has `yarn test:unit` instead, but this fails with
  no tests configured.

- Cache yarn state for quicker results.

To make use of this file, code must be hosted on github and
the specific repository added to travis. To do this, visit
travis-ci.org, log in with github credentials, and authorize
travis to access your github repositories.

Synchonize your account and visit the config for the specific
repository under https://travis-ci.org/account/repositories
to enable travis jobs for that project.

After that travis will run the build commands specified in
this file on every new commit and post feedback on pull requests.
This helps assure that code changes haven't broken something
fundamental to the application.