### PR TITLE
Fix global component loading in production builds.

### DIFF
--- a/src/global-components/index.js
+++ b/src/global-components/index.js
@@ -1,0 +1,7 @@
+import Icon from './Icon.vue';
+import TextLoader from './TextLoader.vue';
+
+export default {
+  Icon,
+  TextLoader,
+};

--- a/src/global-components/index.js
+++ b/src/global-components/index.js
@@ -1,7 +1,0 @@
-import Icon from './Icon.vue';
-import TextLoader from './TextLoader.vue';
-
-export default [
-  Icon,
-  TextLoader,
-];

--- a/src/main.js
+++ b/src/main.js
@@ -3,14 +3,17 @@ import App from './App.vue';
 import store from './store';
 
 import SkeletonPlugin from './skeleton/plugin';
-import globalComponents from './global-components';
 import widgets from './widgets';
 
 Vue.config.productionTip = false;
 
-globalComponents.forEach((component) => {
-  // eslint-disable-next-line no-underscore-dangle
-  Vue.component(component.__file.split('/').pop().split('.')[0], component);
+// Register what's in the global components directory.
+const globalComponents = require.context('./global-components', true, /\.vue$/i);
+
+globalComponents.keys().forEach((path) => {
+  // Component's filename without the extension.
+  const name = path.split('/').pop().split('.')[0];
+  Vue.component(name, globalComponents(path).default);
 });
 
 Vue.use(SkeletonPlugin, { widgets });

--- a/src/main.js
+++ b/src/main.js
@@ -2,18 +2,15 @@ import Vue from 'vue';
 import App from './App.vue';
 import store from './store';
 
+import globalComponents from './global-components';
 import SkeletonPlugin from './skeleton/plugin';
 import widgets from './widgets';
 
 Vue.config.productionTip = false;
 
-// Register what's in the global components directory.
-const globalComponents = require.context('./global-components', true, /\.vue$/i);
-
-globalComponents.keys().forEach((path) => {
-  // Component's filename without the extension.
-  const name = path.split('/').pop().split('.')[0];
-  Vue.component(name, globalComponents(path).default);
+// Register exported global components.
+Object.entries(globalComponents).forEach(([name, component]) => {
+  Vue.component(name, component);
 });
 
 Vue.use(SkeletonPlugin, { widgets });


### PR DESCRIPTION
Instead of maintaining an index.js which re-exports all the vue.js modules in the global-components directory, use webpack's `require.context` loader to iterate over all the contained files and register the components from there.

The previous method constructed component names from the `__file` property of the module objects, but this is only available in debug builds and so the site failed to load when deployed.

Closes #32. Based on [this example](https://vuejs.org/v2/guide/components-registration.html#Automatic-Global-Registration-of-Base-Components) from the vue.js guild.